### PR TITLE
Compiler flag support for SQLite.swift and Android

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,11 +19,14 @@ jobs:
     - name: Run tests
       run: swift test -v
 
-  test-android:
+  linux-android:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Test
+    - name: Test Linux
+      uses: swift test
+    - name: Test Android
       uses: skiptools/swift-android-action@v2
+

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Test Linux
-      uses: swift test
+      run: swift test
     - name: Test Android
       uses: skiptools/swift-android-action@v2
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,3 +18,12 @@ jobs:
       run: swift build -v
     - name: Run tests
       run: swift test -v
+
+  test-android:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Test
+      uses: skiptools/swift-android-action@v2

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let compileTimeOptions: [CSetting] = [
 	// https://sqlite.org/compile.html#dqs
 	.define("SQLITE_DQS", to: "0"),
 	// https://sqlite.org/compile.html#threadsafe
-	.define("SQLITE_THREADSAFE", to: "0"),
+	.define("SQLITE_THREADSAFE", to: "2"),
 	// https://sqlite.org/compile.html#default_memstatus
 	.define("SQLITE_DEFAULT_MEMSTATUS", to: "0"),
 	// https://sqlite.org/compile.html#default_wal_synchronous
@@ -34,9 +34,9 @@ let compileTimeOptions: [CSetting] = [
 	// https://sqlite.org/limits.html#max_expr_depth
 	.define("SQLITE_MAX_EXPR_DEPTH", to: "0"),
 	// https://sqlite.org/compile.html#omit_decltype
-	.define("SQLITE_OMIT_DECLTYPE"),
+//	.define("SQLITE_OMIT_DECLTYPE"),
 	// https://sqlite.org/compile.html#omit_deprecated
-	.define("SQLITE_OMIT_DEPRECATED"),
+//	.define("SQLITE_OMIT_DEPRECATED"),
 	// https://sqlite.org/compile.html#omit_progress_callback
 	.define("SQLITE_OMIT_PROGRESS_CALLBACK"),
 	// https://sqlite.org/compile.html#omit_shared_cache
@@ -44,7 +44,7 @@ let compileTimeOptions: [CSetting] = [
 	// https://sqlite.org/compile.html#use_alloca
 	.define("SQLITE_USE_ALLOCA"),
 	// https://sqlite.org/compile.html#omit_autoinit
-	.define("SQLITE_OMIT_AUTOINIT"),
+//	.define("SQLITE_OMIT_AUTOINIT"),
 	// https://sqlite.org/compile.html#strict_subtype
 	.define("SQLITE_STRICT_SUBTYPE", to: "1"),
 ]
@@ -60,7 +60,9 @@ let platformConfiguration: [CSetting] = [
 /// - seealso: [Options To Enable Features Normally Turned Off](https://sqlite.org/compile.html#_options_to_enable_features_normally_turned_off)
 let features: [CSetting] = [
 	// https://sqlite.org/c3ref/column_database_name.html
-//	.define("SQLITE_ENABLE_COLUMN_METADATA"),
+	.define("SQLITE_ENABLE_COLUMN_METADATA"),
+	// https://sqlite.org/fts4.html
+	.define("SQLITE_ENABLE_FTS4"),
 	// https://sqlite.org/fts5.html
 	.define("SQLITE_ENABLE_FTS5"),
 	// https://sqlite.org/geopoly.html
@@ -70,24 +72,37 @@ let features: [CSetting] = [
 	.define("SQLITE_ENABLE_MATH_FUNCTIONS"),
 	// --> For pre-update hook support uncomment the following define
 	// https://sqlite.org/c3ref/preupdate_blobwrite.html
-//	.define("SQLITE_ENABLE_PREUPDATE_HOOK"),
+	.define("SQLITE_ENABLE_PREUPDATE_HOOK"),
 	// https://sqlite.org/rtree.html
 	.define("SQLITE_ENABLE_RTREE"),
 	// --> For session support uncomment the following define and enable the pre-update hook
 	// https://sqlite.org/sessionintro.html
-//	.define("SQLITE_ENABLE_SESSION"),
+	.define("SQLITE_ENABLE_SESSION"),
 	// https://sqlite.org/c3ref/snapshot.html
 	.define("SQLITE_ENABLE_SNAPSHOT"),
 	// https://sqlite.org/stmt.html
 	.define("SQLITE_ENABLE_STMTVTAB"),
 	// https://sqlite.org/fileformat2.html#stat4tab
 	.define("SQLITE_ENABLE_STAT4"),
+
+	.define("SQLITE_ENABLE_API_ARMOR"),
+	.define("SQLITE_ENABLE_DBSTAT_VTAB"),
+	.define("SQLITE_ENABLE_MEMORY_MANAGEMENT"),
+	.define("SQLITE_ENABLE_PREUPDATE_HOOK"),
+	.define("SQLITE_ENABLE_RTREE"),
+	.define("SQLITE_ENABLE_STMTVTAB"),
+	.define("SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION"),
+	.define("SQLITE_ENABLE_UNLOCK_NOTIFY"),
+	.define("SQLITE_MAX_VARIABLE_NUMBER", to: "250000"),
+	.define("SQLITE_USE_URI"),
+	.define("SQLITE_HAS_CODEC"),
+	.define("SQLITE_TEMP_STORE", to: "2"),
+	.define("HAVE_GETHOSTUUID", to: "0"),
 ]
 
 let package = Package(
 	name: "CSQLite",
 	products: [
-		// Products define the executables and libraries a package produces, making them visible to other packages.
 		.library(
 			name: "CSQLite",
 			targets: [
@@ -95,8 +110,6 @@ let package = Package(
 			]),
 	],
 	targets: [
-		// Targets are the basic building blocks of a package, defining a module or a test suite.
-		// Targets can depend on other targets in this package and products from dependencies.
 		.target(
 			name: "CSQLite",
 			cSettings: compileTimeOptions + platformConfiguration + features + [
@@ -106,6 +119,7 @@ let package = Package(
 			],
 			linkerSettings: [
 				.linkedLibrary("m"),
+				.linkedLibrary("log", .when(platforms: [.android])),
 			]),
 		.testTarget(
 			name: "CSQLiteTests",


### PR DESCRIPTION
This PR adds the necessary compile flags to work as a custom SQLite build for https://github.com/stephencelis/SQLite.swift, as well as adding support for building and testing on Android.

Prior to this fix, attempting to run the SQLite.swift tests on macOS or Android would crash at:

```
Test Case '-[SQLiteTests.ConnectionAttachTests test_attach_detach_file_database]' started.
error: Exited with unexpected signal code 11
```